### PR TITLE
Corruption indication

### DIFF
--- a/DataTanker/Core/DataTanker.Core.csproj
+++ b/DataTanker/Core/DataTanker.Core.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Recovery\RecoveryFile.cs" />
     <Compile Include="Recovery\RecoveryRecord.cs" />
     <Compile Include="Recovery\RecoveryRecordType.cs" />
+    <Compile Include="StorageFlushExceptionEventArgs.cs" />
     <Compile Include="Utils\StreamExtensions.cs" />
     <Compile Include="Settings\AccessMethodSpecificSettingsBase.cs" />
     <Compile Include="Settings\BPlusTreeStorageSettings.cs" />

--- a/DataTanker/Core/IStorage.cs
+++ b/DataTanker/Core/IStorage.cs
@@ -8,6 +8,12 @@
     public interface IStorage : IDisposable
     {
         /// <summary>
+        /// Triggered when there is a storage flush exception - usually
+        /// indicating a corrupted storage (that should be restarted/deleted).
+        /// </summary>
+        event EventHandler<StorageFlushExceptionEventArgs> OnFlushException;
+
+        /// <summary>
         /// Opens an existing storage.
         /// </summary>
         /// <param name="path">A string containing information about storage location</param>

--- a/DataTanker/Core/StorageFlushExceptionEventArgs.cs
+++ b/DataTanker/Core/StorageFlushExceptionEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DataTanker
+{
+    public class StorageFlushExceptionEventArgs : EventArgs
+    {
+      public Exception FlushException { get; set; }
+    }
+}


### PR DESCRIPTION
When having a corrupted storage - the Flush call would throw an unhandled exception.
Wrapping it with a try... catch... and exposing an IStorage event to allow the caller to handle such situations (e.g. deleting the storage and creating a new one).

I managed to simulate this crash by creating a recovery file and opening the storage again - prior to the recoveryFile.dispose fix.